### PR TITLE
fix(security): Upgrade pac4j-jwt to 4.5.9 (CVE-2026-29000)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 		<kotlin.version>1.9.24</kotlin.version>
 		<okhttp3.version>4.12.0</okhttp3.version>
 		<shiro.version>1.13.0</shiro.version>
-		<pac4j.version>4.5.7</pac4j.version>
+		<pac4j.version>4.5.9</pac4j.version>
 		<velocity.tools.version>3.1</velocity.tools.version>
 		<sun.jersey.version>1.19.4</sun.jersey.version>
 		<kafka.version>2.8.2</kafka.version>


### PR DESCRIPTION
## Summary

This PR upgrades `pac4j-jwt` from version **4.5.7** to **4.5.9** to address a critical security vulnerability.

## Vulnerability Details

- **CVE**: [CVE-2026-29000](https://nvd.nist.gov/vuln/detail/CVE-2026-29000)
- **Severity**: Critical (CVSS 9.1)
- **Type**: Authentication bypass in pac4j-jwt
- **Affected versions**: < 4.5.9
- **Fixed version**: 4.5.9+

## Changes

- Updated `pac4j.version` property from `4.5.7` to `4.5.9` in `pom.xml`

## Testing

- `mvn validate` passes successfully
- `mvn compile` passes successfully

## Impact

This is a parent POM change that will cascade to all child projects in the Buession framework ecosystem, ensuring the entire framework uses the patched pac4j-jwt version.

---

📋 _Please enable "Allow edits by maintainers" if not already enabled._